### PR TITLE
Step 18 - 카프카 발행 및 Transactional Outbox Pattern 적용

### DIFF
--- a/src/main/java/kr/hhplus/be/server/order/domain/OrderCompletedEvent.java
+++ b/src/main/java/kr/hhplus/be/server/order/domain/OrderCompletedEvent.java
@@ -1,10 +1,14 @@
 package kr.hhplus.be.server.order.domain;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 public class OrderCompletedEvent {
-    private final Long orderId;
+    private Long orderId;
+
+    public OrderCompletedEvent(Long orderId) {
+        this.orderId = orderId;
+    }
 }

--- a/src/main/java/kr/hhplus/be/server/order/domain/OrderCompletedEventHandler.java
+++ b/src/main/java/kr/hhplus/be/server/order/domain/OrderCompletedEventHandler.java
@@ -1,0 +1,46 @@
+package kr.hhplus.be.server.order.domain;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.hhplus.be.server.order.infra.kafka.KafkaProducer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderCompletedEventHandler {
+    private final OrderOutboxRepository outboxRepository;
+    private final ObjectMapper objectMapper;
+    private final KafkaProducer kafkaProducer;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void saveOutbox(OrderCompletedEvent orderCompletedEvent) {
+        log.info("order completed - save event: {}", orderCompletedEvent);
+
+        try{
+            String jsonPayload = objectMapper.writeValueAsString(orderCompletedEvent);
+            OrderOutbox outbox = OrderOutbox.builder()
+                    .orderId(orderCompletedEvent.getOrderId())
+                    .eventType(orderCompletedEvent.getClass().getSimpleName())
+                    .payload(jsonPayload)
+                    .status(OutboxStatus.PENDING)
+                    .build();
+
+            outboxRepository.save(outbox);
+        } catch (JsonProcessingException e) {
+            log.error(e.getMessage());
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void sendOrderInfo(OrderCompletedEvent orderCompletedEvent) throws JsonProcessingException {
+        String jsonPayload = objectMapper.writeValueAsString(orderCompletedEvent);
+        kafkaProducer.publish("order-completed", jsonPayload);
+        log.info("kafka order-completed event published: {}", orderCompletedEvent);
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/order/domain/OrderOutbox.java
+++ b/src/main/java/kr/hhplus/be/server/order/domain/OrderOutbox.java
@@ -22,6 +22,8 @@ public class OrderOutbox extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private OutboxStatus status;
 
+    private int retryCount;
+
     @Builder
     public OrderOutbox(Long orderId, String eventType, String payload, OutboxStatus status) {
         this.orderId = orderId;
@@ -32,6 +34,10 @@ public class OrderOutbox extends BaseTimeEntity {
 
     public void updateStatus(OutboxStatus status) {
         this.status = status;
+    }
+
+    public void incrementRetryCount() {
+        this.retryCount++;
     }
 
 }

--- a/src/main/java/kr/hhplus/be/server/order/domain/OrderOutbox.java
+++ b/src/main/java/kr/hhplus/be/server/order/domain/OrderOutbox.java
@@ -1,0 +1,37 @@
+package kr.hhplus.be.server.order.domain;
+
+import jakarta.persistence.*;
+import kr.hhplus.be.server.common.entity.BaseTimeEntity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Table(name = "`order_outbox`")
+@Entity
+public class OrderOutbox extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long orderId;
+    private String eventType;
+    private String payload;
+
+    @Enumerated(EnumType.STRING)
+    private OutboxStatus status;
+
+    @Builder
+    public OrderOutbox(Long orderId, String eventType, String payload, OutboxStatus status) {
+        this.orderId = orderId;
+        this.eventType = eventType;
+        this.payload = payload;
+        this.status = status;
+    }
+
+    public void updateStatus(OutboxStatus status) {
+        this.status = status;
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/order/domain/OrderOutboxRepository.java
+++ b/src/main/java/kr/hhplus/be/server/order/domain/OrderOutboxRepository.java
@@ -1,0 +1,9 @@
+package kr.hhplus.be.server.order.domain;
+
+import java.util.List;
+
+public interface OrderOutboxRepository {
+    List<OrderOutbox> findByStatus(OutboxStatus status);
+    void save(OrderOutbox orderOutbox);
+    OrderOutbox findByOrderIdAndEventType(Long id, String eventType);
+}

--- a/src/main/java/kr/hhplus/be/server/order/domain/OutboxScheduler.java
+++ b/src/main/java/kr/hhplus/be/server/order/domain/OutboxScheduler.java
@@ -1,0 +1,37 @@
+package kr.hhplus.be.server.order.domain;
+
+import kr.hhplus.be.server.order.infra.kafka.KafkaProducer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxScheduler {
+    private final OrderOutboxRepository orderOutboxRepository;
+    private final KafkaProducer kafkaProducer;
+
+    @Scheduled(fixedDelay = 60000)
+    public void republish() {
+        List<OrderOutbox> pendingEvents = orderOutboxRepository.findByStatus(OutboxStatus.PENDING);
+
+        for (OrderOutbox orderOutbox : pendingEvents) {
+            try {
+                kafkaProducer.publish("order-completed", orderOutbox.getPayload());
+                orderOutbox.updateStatus(OutboxStatus.PUBLISHED);
+            } catch (Exception e) {
+                log.error("kafka 전송 실패 - orderId : {}", orderOutbox.getOrderId(), e);
+                orderOutbox.incrementRetryCount();
+                if(orderOutbox.getRetryCount() >= 3 ){
+                    orderOutbox.updateStatus(OutboxStatus.FAILED);
+                }
+            } finally {
+                orderOutboxRepository.save(orderOutbox);
+            }
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/order/domain/OutboxStatus.java
+++ b/src/main/java/kr/hhplus/be/server/order/domain/OutboxStatus.java
@@ -1,0 +1,5 @@
+package kr.hhplus.be.server.order.domain;
+
+public enum OutboxStatus {
+    PENDING, PUBLISHED, FAILED
+}

--- a/src/main/java/kr/hhplus/be/server/order/infra/DataPlatform.java
+++ b/src/main/java/kr/hhplus/be/server/order/infra/DataPlatform.java
@@ -1,18 +1,30 @@
 package kr.hhplus.be.server.order.infra;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.hhplus.be.server.order.domain.OrderCompletedEvent;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class DataPlatform {
 
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = "order-completed", groupId = "data-group")
+    public void consume(String message) {
+       log.info("데이터 플랫폼 - consume order completed: {}", message);
+        try {
+            OrderCompletedEvent event = objectMapper.readValue(message, OrderCompletedEvent.class);
+            send(event);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+        }
+    }
+
     public boolean send(OrderCompletedEvent event) {
         log.info("주문 생성 완료 - 데이터 플랫폼으로 주문 정보 전달 - 주문 아이디 : {}", event.getOrderId());
         return true;

--- a/src/main/java/kr/hhplus/be/server/order/infra/OrderOutboxJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/order/infra/OrderOutboxJpaRepository.java
@@ -1,0 +1,12 @@
+package kr.hhplus.be.server.order.infra;
+
+import kr.hhplus.be.server.order.domain.OrderOutbox;
+import kr.hhplus.be.server.order.domain.OutboxStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OrderOutboxJpaRepository extends JpaRepository<OrderOutbox, Long> {
+    List<OrderOutbox> findByStatus(OutboxStatus status);
+    OrderOutbox findByOrderIdAndEventType(Long id, String eventType);
+}

--- a/src/main/java/kr/hhplus/be/server/order/infra/OrderOutboxRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/order/infra/OrderOutboxRepositoryImpl.java
@@ -1,0 +1,32 @@
+package kr.hhplus.be.server.order.infra;
+
+import kr.hhplus.be.server.order.domain.OrderOutbox;
+import kr.hhplus.be.server.order.domain.OrderOutboxRepository;
+import kr.hhplus.be.server.order.domain.OutboxStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderOutboxRepositoryImpl implements OrderOutboxRepository {
+
+    private final OrderOutboxJpaRepository orderOutboxJpaRepository;
+
+    @Override
+    public List<OrderOutbox> findByStatus(OutboxStatus status) {
+        return orderOutboxJpaRepository.findByStatus(status);
+    }
+
+    @Override
+    public void save(OrderOutbox orderOutbox) {
+        orderOutboxJpaRepository.save(orderOutbox);
+    }
+
+    @Override
+    public OrderOutbox findByOrderIdAndEventType(Long id, String eventType) {
+        return orderOutboxJpaRepository.findByOrderIdAndEventType(id, eventType);
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/order/infra/kafka/KafkaConsumer.java
+++ b/src/main/java/kr/hhplus/be/server/order/infra/kafka/KafkaConsumer.java
@@ -1,0 +1,33 @@
+package kr.hhplus.be.server.order.infra.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.hhplus.be.server.order.domain.OrderCompletedEvent;
+import kr.hhplus.be.server.order.domain.OrderOutbox;
+import kr.hhplus.be.server.order.domain.OrderOutboxRepository;
+import kr.hhplus.be.server.order.domain.OutboxStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final OrderOutboxRepository orderOutboxRepository;
+
+    @KafkaListener(topics = "order-completed", groupId = "order-group")
+    public void consume(String message) {
+        log.info("order outbox - consume message: {}", message);
+        try {
+            OrderCompletedEvent event = objectMapper.readValue(message, OrderCompletedEvent.class);
+            OrderOutbox outbox = orderOutboxRepository.findByOrderIdAndEventType(event.getOrderId(), event.getClass().getSimpleName());
+            outbox.updateStatus(OutboxStatus.PUBLISHED);
+            orderOutboxRepository.save(outbox);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/order/infra/kafka/KafkaProducer.java
+++ b/src/main/java/kr/hhplus/be/server/order/infra/kafka/KafkaProducer.java
@@ -1,0 +1,15 @@
+package kr.hhplus.be.server.order.infra.kafka;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaProducer {
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public void publish(String topic, String message) {
+        kafkaTemplate.send(topic, message);
+    }
+}


### PR DESCRIPTION
### **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

카프카 이벤트 발행 및 Transactional Outbox Pattern 적용 : 759e4029a65e0a9ca8e22721657b5717bb53fe0f
발행 실패 케이스 재처리 구현 : 9119b6b3084186c35b2bf29f866bce65fb691587


---
### **리뷰 포인트(질문)**
- 리뷰 포인트 1 : 아웃박스 패턴을 적용하면 컨슈머가 최소 2개 생기는거로 이해했습니다. 제가 이해한게 맞을까요? 그리고, 발행 서비스의 컨슈머가 아웃박스 상태를 갱신할 때 해당 아웃박스 값을 찾는 키를 따로 가져야 할까요? 지금은 '주문결제완료' 이벤트에 대한 주문 id 는 하나 밖에 없을 것이라 생각해서 order_id, event_type 으로 확인하고 있습니다. 
- 리뷰 포인트 2 : 스케줄러로 1분마다 확인하여 최대 3회의 재시도를 하도록 구현하였습니다. 해당 로직이 적절한지 검토 부탁드립니다!
<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->
꾸준함

### Problem
<!--개선이 필요한 점-->
조급함

### Try
<!-- 새롭게 시도할 점 -->
